### PR TITLE
Add `task-definitions env` commands 

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,10 @@ task-definitions
   - [x] edit
   - [ ] delete
   - [ ] deregister
-  - [ ] env
-    - [ ] list
-    - [ ] set
-    - [ ] delete
+  - [x] env
+    - [x] list
+    - [x] set
+    - [x] delete
 
 scheduled-tasks
   - [x] create

--- a/cmd/flagsHelpSpec.go
+++ b/cmd/flagsHelpSpec.go
@@ -150,3 +150,6 @@ var commandOverride string
 
 var latestTaskDefinition bool
 var latestTaskDefinitionSpec = "Get the latest Task Definition revision (not deprecated) to use as source"
+
+var taskDefinitionsEnvOverride bool
+var taskDefinitionsEnvOverrideSpec = "Override container's environment variables"

--- a/cmd/task_definitions_env.go
+++ b/cmd/task_definitions_env.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func taskDefinitionsEnvRun(cmd *cobra.Command, args []string) {
+	cmd.Help()
+}
+
+var taskDefinitionsEnvCmd = &cobra.Command{
+	Use:   "env [command]",
+	Short: "Commands to manage Task Definitions' environment variables",
+	Run:   taskDefinitionsEnvRun,
+}
+
+func init() {
+	taskDefinitionsCmd.AddCommand(taskDefinitionsEnvCmd)
+}

--- a/cmd/task_definitions_env_delete.go
+++ b/cmd/task_definitions_env_delete.go
@@ -1,0 +1,87 @@
+package cmd
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func taskDefinitionsEnvDeleteRun(cmd *cobra.Command, args []string) {
+	tdDescription, err := ecsI.DescribeTaskDefinition(&ecs.DescribeTaskDefinitionInput{
+		TaskDefinition: aws.String(args[0]),
+	})
+	t.Must(err)
+
+	td := tdDescription.TaskDefinition
+
+	var cdToUpdate *ecs.ContainerDefinition
+
+	if containerName == "" {
+		cdToUpdate = td.ContainerDefinitions[0]
+	} else {
+		for _, cd := range td.ContainerDefinitions {
+			if aws.StringValue(cd.Name) == containerName {
+				cdToUpdate = cd
+				break
+			}
+		}
+	}
+
+	if cdToUpdate == nil {
+		t.Exitf("No container on the Task Family %s\n", aws.StringValue(td.Family))
+	}
+
+	env := cdToUpdate.Environment
+
+	envKeys := viper.GetStringSlice("keys")
+
+	for _, key := range envKeys {
+		for i, envKeyValuePair := range env {
+			if aws.StringValue(envKeyValuePair.Name) == key {
+				env = append(env[:i], env[i+1:]...)
+				break
+			}
+		}
+	}
+
+	cdToUpdate.Environment = env
+
+	t.Must(ecsI.RegisterTaskDefinition(&ecs.RegisterTaskDefinitionInput{
+		ContainerDefinitions:    td.ContainerDefinitions,
+		Cpu:                     td.Cpu,
+		ExecutionRoleArn:        td.ExecutionRoleArn,
+		Family:                  td.Family,
+		IpcMode:                 td.IpcMode,
+		Memory:                  td.Memory,
+		NetworkMode:             td.NetworkMode,
+		PidMode:                 td.PidMode,
+		PlacementConstraints:    td.PlacementConstraints,
+		ProxyConfiguration:      td.ProxyConfiguration,
+		RequiresCompatibilities: td.RequiresCompatibilities,
+		TaskRoleArn:             td.TaskRoleArn,
+		Volumes:                 td.Volumes,
+	}))
+}
+
+var taskDefinitionsEnvDeleteCmd = &cobra.Command{
+	Use:              "delete [task-definition]",
+	Short:            "Delete a Task Definition's environment variables",
+	Args:             cobra.ExactArgs(1),
+	Run:              taskDefinitionsEnvDeleteRun,
+	PersistentPreRun: persistentPreRun,
+}
+
+func init() {
+	taskDefinitionsEnvCmd.AddCommand(taskDefinitionsEnvDeleteCmd)
+
+	flags := taskDefinitionsEnvDeleteCmd.Flags()
+
+	flags.StringVar(&containerName, "container", "", containerNameSpec)
+	viper.BindPFlag("container", taskDefinitionsEnvDeleteCmd.Flags().Lookup("container"))
+
+	flags.StringSliceP("keys", "k", []string{}, "Delete Environment Variables of the Task. Inform the variable names. Can be informed multiple times.")
+	viper.BindPFlag("keys", taskDefinitionsEnvDeleteCmd.Flags().Lookup("keys"))
+
+	flags.BoolVar(&taskDefinitionsEnvOverride, "override", false, taskDefinitionsEnvOverrideSpec)
+}

--- a/cmd/task_definitions_env_list.go
+++ b/cmd/task_definitions_env_list.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func taskDefinitionsEnvListRun(cmd *cobra.Command, args []string) {
+	tdDescription, err := ecsI.DescribeTaskDefinition(&ecs.DescribeTaskDefinitionInput{
+		TaskDefinition: aws.String(args[0]),
+	})
+	t.Must(err)
+
+	td := tdDescription.TaskDefinition
+
+	var targetCd *ecs.ContainerDefinition
+
+	if containerName == "" {
+		targetCd = td.ContainerDefinitions[0]
+	} else {
+		for _, cd := range td.ContainerDefinitions {
+			if aws.StringValue(cd.Name) == containerName {
+				targetCd = cd
+				break
+			}
+		}
+	}
+
+	if targetCd == nil {
+		t.Exitf("No container on the Task Family %s\n", aws.StringValue(td.Family))
+	}
+
+	for _, envVar := range targetCd.Environment {
+		t.Outf("%s=%s\n", aws.StringValue(envVar.Name), aws.StringValue(envVar.Value))
+	}
+}
+
+var taskDefinitionsEnvListCmd = &cobra.Command{
+	Use:              "list [task-definition]",
+	Short:            "List a Task Definition's environment variables",
+	Args:             cobra.ExactArgs(1),
+	Run:              taskDefinitionsEnvListRun,
+	PersistentPreRun: persistentPreRun,
+}
+
+func init() {
+	taskDefinitionsEnvCmd.AddCommand(taskDefinitionsEnvListCmd)
+
+	flags := taskDefinitionsEnvListCmd.Flags()
+
+	flags.StringVar(&containerName, "container", "", containerNameSpec)
+	viper.BindPFlag("container", taskDefinitionsEnvListCmd.Flags().Lookup("container"))
+}

--- a/cmd/task_definitions_env_set.go
+++ b/cmd/task_definitions_env_set.go
@@ -1,0 +1,90 @@
+package cmd
+
+import (
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func taskDefinitionsEnvSetRun(cmd *cobra.Command, args []string) {
+	tdDescription, err := ecsI.DescribeTaskDefinition(&ecs.DescribeTaskDefinitionInput{
+		TaskDefinition: aws.String(args[0]),
+	})
+	t.Must(err)
+
+	td := tdDescription.TaskDefinition
+
+	var cdToUpdate *ecs.ContainerDefinition
+
+	if containerName == "" {
+		cdToUpdate = td.ContainerDefinitions[0]
+	} else {
+		for _, cd := range td.ContainerDefinitions {
+			if aws.StringValue(cd.Name) == containerName {
+				cdToUpdate = cd
+				break
+			}
+		}
+	}
+
+	if cdToUpdate == nil {
+		t.Exitf("No container on the Task Family %s\n", aws.StringValue(td.Family))
+	}
+
+	env := cdToUpdate.Environment
+
+	if taskDefinitionsEnvOverride {
+		env = make([]*ecs.KeyValuePair, 0)
+	}
+
+	for _, envPair := range environmentVariables {
+		envSlice := strings.Split(envPair, "=")
+		if len(envSlice) != 2 {
+			continue
+		}
+
+		env = append(env, &ecs.KeyValuePair{Name: aws.String(envSlice[0]), Value: aws.String(envSlice[1])})
+	}
+
+	cdToUpdate.Environment = env
+
+	t.Must(ecsI.RegisterTaskDefinition(&ecs.RegisterTaskDefinitionInput{
+		ContainerDefinitions:    td.ContainerDefinitions,
+		Cpu:                     td.Cpu,
+		ExecutionRoleArn:        td.ExecutionRoleArn,
+		Family:                  td.Family,
+		IpcMode:                 td.IpcMode,
+		Memory:                  td.Memory,
+		NetworkMode:             td.NetworkMode,
+		PidMode:                 td.PidMode,
+		PlacementConstraints:    td.PlacementConstraints,
+		ProxyConfiguration:      td.ProxyConfiguration,
+		RequiresCompatibilities: td.RequiresCompatibilities,
+		TaskRoleArn:             td.TaskRoleArn,
+		Volumes:                 td.Volumes,
+	}))
+}
+
+var taskDefinitionsEnvSetCmd = &cobra.Command{
+	Use:              "set [task-definition]",
+	Short:            "Set a Task Definition's environment variables",
+	Args:             cobra.ExactArgs(1),
+	Run:              taskDefinitionsEnvSetRun,
+	PersistentPreRun: persistentPreRun,
+}
+
+func init() {
+	taskDefinitionsEnvCmd.AddCommand(taskDefinitionsEnvSetCmd)
+
+	flags := taskDefinitionsEnvSetCmd.Flags()
+
+	flags.StringVar(&containerName, "container", "", containerNameSpec)
+	viper.BindPFlag("container", taskDefinitionsEnvSetCmd.Flags().Lookup("container"))
+
+	flags.StringSliceVarP(&environmentVariables, "env", "e", []string{}, environmentVariablesSpec)
+
+	flags.BoolVar(&taskDefinitionsEnvOverride, "override", false, taskDefinitionsEnvOverrideSpec)
+}


### PR DESCRIPTION
`task-definitions env [task-definition] list` to list environment variables from target TD
`task-definitions env [task-definition] set -e "KEY=VALUE"` to add/update environment variables from target TD
`task-definitions env [task-definition] delete -k "KEY" -k "KEY2"` to delete environment variables from target TD