### PR TITLE
Making set `env` and delete `keys` flags required + adding `keys` to helper

### DIFF
--- a/cmd/flagsHelpSpec.go
+++ b/cmd/flagsHelpSpec.go
@@ -102,6 +102,9 @@ var environmentVariables []string
 var environmentVariablesSpec = `Overwrite or add Environment Variables of the Task. Inform as "key=value" format.
 Can be informed multiple times.`
 
+var environmentVariableKeys []string
+var environmentVariableKeysSpec = `Key of the Environment Variables to delete from Task. Can be informed multiple times. E.g. --key [ENV_KEY1] -k [ENV_KEY2]`
+
 var credit string
 var creditSpec = `The credit option for CPU usage of a T2 (default 'standard') or T3 (default 'unlimited') instance
 Valid values: 'standard', 'unlimited'`

--- a/cmd/task_definitions_env_delete.go
+++ b/cmd/task_definitions_env_delete.go
@@ -34,9 +34,7 @@ func taskDefinitionsEnvDeleteRun(cmd *cobra.Command, args []string) {
 
 	env := cdToUpdate.Environment
 
-	envKeys := viper.GetStringSlice("keys")
-
-	for _, key := range envKeys {
+	for _, key := range environmentVariableKeys {
 		for i, envKeyValuePair := range env {
 			if aws.StringValue(envKeyValuePair.Name) == key {
 				env = append(env[:i], env[i+1:]...)
@@ -80,8 +78,8 @@ func init() {
 	flags.StringVar(&containerName, "container", "", containerNameSpec)
 	viper.BindPFlag("container", taskDefinitionsEnvDeleteCmd.Flags().Lookup("container"))
 
-	flags.StringSliceP("keys", "k", []string{}, "Delete Environment Variables of the Task. Inform the variable names. Can be informed multiple times.")
-	viper.BindPFlag("keys", taskDefinitionsEnvDeleteCmd.Flags().Lookup("keys"))
+	flags.StringSliceVarP(&environmentVariableKeys, "keys", "k", []string{}, environmentVariableKeysSpec)
+	taskDefinitionsEnvDeleteCmd.MarkFlagRequired("keys")
 
 	flags.BoolVar(&taskDefinitionsEnvOverride, "override", false, taskDefinitionsEnvOverrideSpec)
 }

--- a/cmd/task_definitions_env_set.go
+++ b/cmd/task_definitions_env_set.go
@@ -85,6 +85,7 @@ func init() {
 	viper.BindPFlag("container", taskDefinitionsEnvSetCmd.Flags().Lookup("container"))
 
 	flags.StringSliceVarP(&environmentVariables, "env", "e", []string{}, environmentVariablesSpec)
+	taskDefinitionsEnvSetCmd.MarkFlagRequired("env")
 
 	flags.BoolVar(&taskDefinitionsEnvOverride, "override", false, taskDefinitionsEnvOverrideSpec)
 }


### PR DESCRIPTION
Making `env` flag from `task-definitions env set` required
Making `keys` flag from `task-definitions env delete` required
Adding `keys` flag to a variable and adding helper spec